### PR TITLE
ModelSerializer.get_pretech_fields

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tortoise-serializer"
-version = "1.3.0"
+version = "1.3.1"
 description = "Pydantic serialization for tortoise-orm"
 authors = ["Sebastien Nicolet <snicolet95@gmail.com>"]
 license = "MIT"

--- a/tests/test_model_serializer.py
+++ b/tests/test_model_serializer.py
@@ -137,3 +137,22 @@ async def test_one_to_one():
     assert serializer.name == person.name
     assert serializer.location.id == person.location.id
     assert serializer.location.name == person.location.name
+
+
+def test_nested_serializer_get_prefetch_fields():
+    class LocationSerializer(ModelSerializer[Location]):
+        id: int
+
+    class BookSerializer(ModelSerializer[Book]):
+        id: int
+        title: str
+
+    class PersonSerializer(ModelSerializer[Person]):
+        id: int
+        name: str
+        location: LocationSerializer | None
+        books: list[BookSerializer]
+
+    # books does not exists in the `Person` model so it should not be there
+    assert "books" not in PersonSerializer.get_prefetch_fields()
+    assert "location" in PersonSerializer.get_prefetch_fields()


### PR DESCRIPTION
Improved ModelSerializer.get_pretech_fields by ommiting fields that are not in the model + gave the ability to filter them properly in Serializer